### PR TITLE
Add steps to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,15 @@ jobs:
         working-directory: ./backend
         
     steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '18.x'
+        cache: 'npm'
+        cache-dependency-path: ./backend/package-lock.json
+    - run: npm install
+    - run: npm run lint
+    - run: npm run test:coverage
 
   frontend-tests:
     runs-on: ubuntu-latest
@@ -22,4 +31,12 @@ jobs:
         working-directory: ./frontend
         
     steps:
-    
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '18.x'
+        cache: 'npm'
+        cache-dependency-path: ./frontend/package-lock.json
+    - run: npm install
+    - run: npm run test:coverage
+    - run: npm run build


### PR DESCRIPTION
**CI workflow improvements:**

* Added `actions/checkout@v4` and `actions/setup-node@v4` to both backend and frontend jobs to use the latest Node.js setup practices and enable npm caching for faster installs
* Updated backend job to explicitly run `npm install`, `npm run lint`, and `npm run test:coverage` for improved clarity and reliability.
* Updated frontend job to explicitly run `npm install`, `npm run test:coverage`, and `npm run build` to ensure all necessary steps are covered in CI.